### PR TITLE
upgrade a list of device on my raspberries 

### DIFF
--- a/NucLibUsb.c
+++ b/NucLibUsb.c
@@ -86,54 +86,138 @@ int NUC_WritePipe(int id,unsigned char *buf,int len)
 	}
 	return 0;
 }
-libusb_device_handle * libusb_open_device_with_vid_pid_index( libusb_context *ctx,
-                                                              unsigned int vendor_id,
-                                                              unsigned int product_id,
-                                                              int index
+
+int compare_port_path(uint8_t *port_numbers1,int port_numbers_len1,uint8_t *port_numbers2,int port_numbers_len2)
+{
+    int iRet;
+	int i;
+
+	if(port_numbers_len1 != port_numbers_len2)
+    {
+        iRet = port_numbers_len1-port_numbers_len1;
+    }
+
+	for(i=0;i< port_numbers_len1;i++)
+	{
+	    if(port_numbers1[i] != port_numbers2[i])
+	    {
+	        iRet = port_numbers1[i] - port_numbers2[i];
+	        break;
+	    }
+	}
+
+	return iRet;
+	
+}
+
+void sort_dev_array(libusb_device **dev_arr,int count)
+{
+    int i,j;
+	libusb_device *tmp;
+	uint8_t port_numbers1[8];
+	uint8_t port_numbers2[8];
+	int port_numbers_len1;
+	int port_numbers_len2;
+	for(int i=0;i<count-1;i++)
+	{
+	    for(j=count -1;j>i;j--)
+	    {
+	        port_numbers_len1 = libusb_get_port_numbers(dev_arr[j-1],port_numbers1,sizeof(port_numbers1));
+			port_numbers_len2 = libusb_get_port_numbers(dev_arr[j],port_numbers2,sizeof(port_numbers2));
+	        if(compare_port_path(port_numbers1,port_numbers_len1,port_numbers2,port_numbers_len2) > 0 )
+	        {
+	            tmp = dev_arr[j-1];
+				dev_arr[j-1] = dev_arr[j];
+				dev_arr[j] = tmp;
+	        }      
+	    }
+	}
+    
+}
+
+void print_port_numbers(libusb_device *dev)
+{
+    uint8_t port_numbers[8];
+	int port_numbers_len;
+	int i;
+	port_numbers_len = libusb_get_port_numbers(dev,port_numbers,sizeof(port_numbers));
+	if(port_numbers_len > 0)
+	{
+	    printf(" %d", port_numbers[0]);
+		for (i = 1; i <port_numbers_len; i++)
+		printf(".%d", port_numbers[i]);
+	}
+}
+
+libusb_device_handle * libusb_open_device_with_vid_pid_index
+(
+libusb_context *ctx,
+unsigned int vendor_id,
+unsigned int product_id,
+int index
 )
 {
-	libusb_device **devs;
+    libusb_device **devs;
 	ssize_t cnt;
 	libusb_device *dev;
+	libusb_device *dev_arr[100];
 	int i=0,j=0,count=0;
 	libusb_device_handle *dev_handle;
 	
 	cnt = libusb_get_device_list(NULL,&devs);
 	if(cnt < 0)
 	{
-        return NULL;
+	     printf("get device list failed\n");
+             return NULL;
 	}
-	while((dev = devs[i++]) != NULL)
+	while(((dev = devs[i++]) != NULL)&&(count < 100))
 	{
-	    struct libusb_device_descriptor desc;
-	    
-	    int r = libusb_get_device_descriptor(dev,&desc);
-	    if(r < 0)
-	    {
-            fprintf(stderr,"failed to get device descriptor\r\n");
-		    return NULL;
-	    }
-	    if((desc.idVendor == vendor_id)&&(desc.idProduct == product_id))
-	    {
-		    count++;
-		    if(count == index)
-		    {
-                r = libusb_open(dev,&dev_handle);
-		        if(r <  0 )
-	            {
-			        printf("r = %d\r\n",r);
-	                return NULL;
-		        }
-		        else
-		        {
-			        return dev_handle;
-		        }
-		    }
-	    }
+	     
+	       struct libusb_device_descriptor desc; 
+		   int r = libusb_get_device_descriptor(dev,&desc);
+		   if(r < 0)
+		   {
+				fprintf(stderr,"failed to get device descriptor\r\n");
+		        return NULL;
+		   }
+		   if((desc.idVendor == vendor_id)&&(desc.idProduct == product_id))
+	       {  
+				dev_arr[count] = dev;
+				count++;
+				//printf("devarr[%d] device =%d port_num=%d \r\n",count-1,libusb_get_device_address(dev),libusb_get_port_number(dev));
+		   }
+    }
+	libusb_free_device_list(devs, 1);
+
+	if(count == 0)
+	{
+            printf("count =0\n");
+	    return NULL;
 	}
+    
+	sort_dev_array(dev_arr,count);
+	
+    if(index > count)
+    {
+    	printf("index > count");
+        return NULL;
+    }
+	printf("usb port is ");
+	print_port_numbers(dev_arr[index-1]);
+    printf("\r\n");
+    int r;
+	r = libusb_open(dev_arr[index-1],&dev_handle);
+    if(r !=  0 )
+    {
+	     printf("r = %d\r\n",r);
+         return NULL;
+    }
+    else
+    {
+	     return dev_handle;
+    }
 	return NULL;
 }
-
 int NUC_OpenUsb(void)
 {
 	int ret=0;
@@ -142,7 +226,8 @@ int NUC_OpenUsb(void)
 
 	if(handle!=NULL) return 0;
 	//Open Device with VendorID and ProductID
-
+	//handle = libusb_open_device_with_vid_pid(ctx,
+	//         USB_VENDOR_ID, USB_PRODUCT_ID);
 	handle = libusb_open_device_with_vid_pid_index(ctx,
 	         USB_VENDOR_ID, USB_PRODUCT_ID,index);
 	if (!handle) {

--- a/common.h
+++ b/common.h
@@ -103,4 +103,6 @@ struct _INFO_T m_info;
 libusb_context *ctx;
 libusb_device_handle *handle;
 
+unsigned int csg_usb_index;
+
 #endif

--- a/main.c
+++ b/main.c
@@ -206,7 +206,6 @@ int main(int argc, char **argv)
 			} else {
 				fprintf(stderr,"Unknown mode\n");
 			}
-
 			break;
 
 		case 't':
@@ -225,7 +224,6 @@ int main(int argc, char **argv)
 			} else {
 				fprintf(stderr,"Unknown type\n");
 			}
-
 			break;
 		case 'e':
 			erase_tag = 1;
@@ -236,7 +234,8 @@ int main(int argc, char **argv)
 			print_using();
 			return 0;
 			break;
-         case 'c':
+                case 'c':
+
 			csg_usb_index = atoi(argv[optind]);
 			break;
 
@@ -250,8 +249,7 @@ int main(int argc, char **argv)
 			break;
 		}
 	}
-
-
+        
 	if(strlen(DDR_fileName)==0) {
 		fprintf(stderr, "Not setting DDR file\n");
 		return -1;

--- a/main.c
+++ b/main.c
@@ -82,6 +82,7 @@ int main(int argc, char **argv)
 	int cmd_opt = 0;
 	memcpy(Data_Path,argv[0],strlen(argv[0]));
 	path=strrchr(Data_Path,'/');
+	csg_usb_index=1;
 	if(path==NULL) {
 #ifndef _WIN32
 		Data_Path[0]='.';
@@ -101,8 +102,7 @@ int main(int argc, char **argv)
 	//fprintf(stderr, "argc:%d\n", argc);
 	while(1) {
 		//fprintf(stderr, "proces index:%d\n", optind);
-		cmd_opt = getopt(argc, argv, "a:d:e:i:nvhw:r:t:m:z::");
-
+		cmd_opt = getopt(argc, argv, "a:d:e:i:nvhw:r:t:m:z::c::");
 		/* End condition always first */
 		if (cmd_opt == -1) {
 			break;
@@ -236,7 +236,9 @@ int main(int argc, char **argv)
 			print_using();
 			return 0;
 			break;
-
+         case 'c':
+			csg_usb_index = atoi(argv[optind]);
+			break;
 
 		/* Error handle: Mainly missing arg or illegal option */
 		case '?':


### PR DESCRIPTION
nuwriter 这个程序每次运行的时候就是一个进程，这时候有个全局变量handle指向要升级的设备。在进程启动后，会获取树莓派上usb的list，但是这个list是无序的。这时候需要根据port_numbersp排序，存在一个数组里面，这样每次运行nuwriter实际上是起一个进程，每次进程里面存的usb的数组是相同的。这个时候我们只需要增加一个参数，-c表示是要升级第几个usb，然后把第几个数组元素赋值给这个全局handle，从第1个开始，1-》2-》3-》4这种，这样每次启动nuwriter就会在依次通过不同的usb口去升级设备了。

The nuwriter program is a process every time it runs, when a global variable handle points to the device to be upgraded. After the process starts, a list of raspberries dispatched with USB is obtained, but the list is out of order. At this point, you need to sort by port_numbersp, there is an array, so each run of nuwriter is actually a process, each process contains the same USB array. At this point, we only need to add a parameter, - C means to upgrade the number of usb, and then assign the number of array elements to the global handle, starting from the first, 1-"2-" 3-"4, so that every time nuwriter starts, it will upgrade the device through different USB ports in turn.